### PR TITLE
🐛 Replace Update-ModuleManifest with Update-Metadata due to bug

### DIFF
--- a/Source/Press.psd1
+++ b/Source/Press.psd1
@@ -107,7 +107,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-            # ReleaseNotes = ''
+        ReleaseNotes = ''
 
         # Prerelease string of this module
         Prerelease = 'NotBuiltYet'

--- a/Source/Press.tasks.ps1
+++ b/Source/Press.tasks.ps1
@@ -85,7 +85,8 @@ Task Press.SetReleaseNotes Press.ReleaseNotes, {
     $ReleaseNotesCompare = [text.encoding]::UTF8.GetBytes($ReleaseNotes) | Where-Object { $_ -ne 10 }
     $ReleaseNotesNewCompare = [text.encoding]::UTF8.GetBytes($newReleaseNotes) | Where-Object { $_ -ne 10 }
     if (-not $ReleaseNotes -or (Compare-Object $ReleaseNotesCompare $ReleaseNotesNewCompare)) {
-        Update-ModuleManifest -Path $ModuleOutManifest -ReleaseNotes $newReleaseNotes.Trim()
+        #BUG: Do not use update-modulemanifest because https://github.com/PowerShell/PowerShellGetv2/issues/294
+        BuildHelpers\Update-Metadata -Path $ModuleOutManifest -Property ReleaseNotes -Value $newReleaseNotes.Trim()
     }
 }
 

--- a/Source/Public/Set-Version.ps1
+++ b/Source/Public/Set-Version.ps1
@@ -18,15 +18,14 @@ function Set-Version {
     # $currentVersion = Get-Metadata -Path $Path -PropertyName 'ModuleVersion'
     if ($currentVersion -ne $Version) {
         Write-Verbose "Current Manifest Version $currentVersion doesn't match $Version. Updating..."
-        # BuildHelpers\Update-Metadata -Path $Path -PropertyName 'ModuleVersion' -Value $Version
-        Update-ModuleManifest -Path $Path -ModuleVersion $Version
+        BuildHelpers\Update-Metadata -Path $Path -PropertyName ModuleVersion -Value $Version
     }
     
     # $currentPreRelease = BuildHelpers\Get-Metadata -Path $Path -PropertyName 'PreRelease'
     $currentPreRelease = $Manifest.privatedata.psdata.prerelease
     if ($currentPreRelease -ne $PreRelease)  {
         Write-Verbose "Current Manifest Prerelease Tag $currentPreRelease doesn't match $PreRelease. Updating..."
-        # BuildHelpers\Update-Metadata -Path $Path -PropertyName 'PreRelease' -Value $PreRelease
-        Update-ModuleManifest -Path $Path -Prerelease $PreRelease
+        #HACK: Do not use update-modulemanifest because https://github.com/PowerShell/PowerShellGetv2/issues/294
+        BuildHelpers\Update-Metadata -Path $Path -PropertyName PreRelease -Value $PreRelease
     }
 }

--- a/Source/Public/Update-PublicFunctions.ps1
+++ b/Source/Public/Update-PublicFunctions.ps1
@@ -25,6 +25,7 @@ function Update-PublicFunctions {
     $currentFunctions = Get-Metadata -Path $Path -PropertyName FunctionsToExport
     if (Compare-Object $currentFunctions $functions) {
         Write-Verbose "Current Function List in manifest doesn't match. Current: $currentFunctions New: $Functions. Updating."
+        #HACK: Don't use Update-ModuleManifest because of https://github.com/PowerShell/PowerShellGetv2/issues/294
         BuildHelpers\Update-Metadata -Path $Path -PropertyName FunctionsToExport -Value $Functions
     }
 }


### PR DESCRIPTION
Update-ModuleManifest messed up private data per https://github.com/PowerShell/PowerShellGetv2/issues/294, so we use Update-Metadata instead.