### PR TITLE
Update Update-PublicFunctions.ps1

### DIFF
--- a/Source/Public/Update-PublicFunctions.ps1
+++ b/Source/Public/Update-PublicFunctions.ps1
@@ -24,7 +24,7 @@ function Update-PublicFunctions {
     }
 
     $currentFunctions = Get-Metadata -Path $Path -PropertyName FunctionsToExport
-    if (Compare-Object $currentFunctions $functions) {
+    if (Compare-Object ($currentFunctions ?? '' ) $functions) {
         Write-Verbose "Current Function List in manifest doesn't match. Current: $currentFunctions New: $Functions. Updating."
         #HACK: Don't use Update-ModuleManifest because of https://github.com/PowerShell/PowerShellGetv2/issues/294
         if ($PSCmdlet.ShouldProcess($Path, "Add Functions $($Functions -join ', ')")) {

--- a/Source/Public/Update-PublicFunctions.ps1
+++ b/Source/Public/Update-PublicFunctions.ps1
@@ -24,7 +24,7 @@ function Update-PublicFunctions {
     }
 
     $currentFunctions = Get-Metadata -Path $Path -PropertyName FunctionsToExport
-    if (Compare-Object ($currentFunctions ?? '' ) $functions) {
+    if (Compare-Object ($currentFunctions ?? @('') ) $functions) {
         Write-Verbose "Current Function List in manifest doesn't match. Current: $currentFunctions New: $Functions. Updating."
         #HACK: Don't use Update-ModuleManifest because of https://github.com/PowerShell/PowerShellGetv2/issues/294
         if ($PSCmdlet.ShouldProcess($Path, "Add Functions $($Functions -join ', ')")) {


### PR DESCRIPTION
In trying to build your module SecretManagement.KeePass, I found $currentFunctions was null. SecretManagement.KeePass.psd1 does contain this data but Get-Metadata was returning null on my workstation ¯\_(ツ)_/¯. This causes compare-object to error out.